### PR TITLE
Tower and Road Changes

### DIFF
--- a/Assets/Sprites/Road.meta
+++ b/Assets/Sprites/Road.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4eb6904d50434164cb46204e8d777773
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Road/Home Base - Horizontal.png
+++ b/Assets/Sprites/Road/Home Base - Horizontal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c901825ce89756aa2fa6242bebe4495fe5080a37169a9ab73b346b7a5c432cb0
+size 7845

--- a/Assets/Sprites/Road/Home Base - Horizontal.png.meta
+++ b/Assets/Sprites/Road/Home Base - Horizontal.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 746433acf004206499e1a07346b92c74
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Home Base - Vertical.png
+++ b/Assets/Sprites/Road/Home Base - Vertical.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:323dd8b26fdfb5414f53b253749d8cf8c71a2947396f95a242981efac20b647b
+size 7721

--- a/Assets/Sprites/Road/Home Base - Vertical.png.meta
+++ b/Assets/Sprites/Road/Home Base - Vertical.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 8bf21431defe875478997aa8547797ad
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Portal - Bottom.png
+++ b/Assets/Sprites/Road/Portal - Bottom.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c77bea2cf4a50293fb939d90ab3e13835df55df0595ffdf7bfe25b7da21cae5
+size 16143

--- a/Assets/Sprites/Road/Portal - Bottom.png.meta
+++ b/Assets/Sprites/Road/Portal - Bottom.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 653aaab804a183f419e3d06e30d51c68
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Portal - Left.png
+++ b/Assets/Sprites/Road/Portal - Left.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49f70bfd91dc31a2b867c2c312ddc70cbcf8a6ef42a923cf8fd888797f675f26
+size 16116

--- a/Assets/Sprites/Road/Portal - Left.png.meta
+++ b/Assets/Sprites/Road/Portal - Left.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 6573a4c201bf9cd48b67a772a7e18a25
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Portal - Right.png
+++ b/Assets/Sprites/Road/Portal - Right.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41b7168fd50d7a7de2a1bab05b2aab0d2bd9fd821d83304b582e7156f3e10608
+size 16192

--- a/Assets/Sprites/Road/Portal - Right.png.meta
+++ b/Assets/Sprites/Road/Portal - Right.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: c67705ee5fd90aa40b61a9179e72c1f6
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Portal - Top.png
+++ b/Assets/Sprites/Road/Portal - Top.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c98a6f16f44b3a12bb2b8b4847c117ed1fc2f80319e6ac43fdfd4ed87c1f65a7
+size 16146

--- a/Assets/Sprites/Road/Portal - Top.png.meta
+++ b/Assets/Sprites/Road/Portal - Top.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 52db875a8fdca244eb7a35e857e360c6
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Road - Horizontal.png
+++ b/Assets/Sprites/Road/Road - Horizontal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c68905a92871347d52fac3d8b02ed9ed372e79d1c962554ebd8d17a9de2daa7b
+size 875

--- a/Assets/Sprites/Road/Road - Horizontal.png.meta
+++ b/Assets/Sprites/Road/Road - Horizontal.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 7c1c510f477be7a459ea18c6e77d3c3f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Road - Vertical.png
+++ b/Assets/Sprites/Road/Road - Vertical.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:048cf7b14c7db0898795a3b73b962e71bb44480a0a883e2fbc1d61e9217f9b20
+size 890

--- a/Assets/Sprites/Road/Road - Vertical.png.meta
+++ b/Assets/Sprites/Road/Road - Vertical.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: c033704661adf8d499711e0a47ef109c
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Road Curve - Bottom Left.png
+++ b/Assets/Sprites/Road/Road Curve - Bottom Left.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51dea424211910b5a56c6006cb47c55ece188c42c95f33730d4a556cc4c3b012
+size 919

--- a/Assets/Sprites/Road/Road Curve - Bottom Left.png.meta
+++ b/Assets/Sprites/Road/Road Curve - Bottom Left.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: f0577b7a605bc4c498c63ffe8cdfff91
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Road Curve - Bottom Right.png
+++ b/Assets/Sprites/Road/Road Curve - Bottom Right.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef5ba56bef4698314b2eb8a760259fe855acdbd9046277d68ae15e8ce46c4306
+size 907

--- a/Assets/Sprites/Road/Road Curve - Bottom Right.png.meta
+++ b/Assets/Sprites/Road/Road Curve - Bottom Right.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 7dfdbf69b0c51fd44a82cd87970eee16
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Road Curve - Top Left.png
+++ b/Assets/Sprites/Road/Road Curve - Top Left.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c87a95291c52ff82cc0484d40b240900ece5321ae701347cdae6718d0246decb
+size 899

--- a/Assets/Sprites/Road/Road Curve - Top Left.png.meta
+++ b/Assets/Sprites/Road/Road Curve - Top Left.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 525e419ffb01b9240ad188051a0d1751
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Road/Road Curve - Top Right.png
+++ b/Assets/Sprites/Road/Road Curve - Top Right.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa22c2e49f91936276b1c27b946bfebba409fa22f6a725d5c5a10277a2e13339
+size 908

--- a/Assets/Sprites/Road/Road Curve - Top Right.png.meta
+++ b/Assets/Sprites/Road/Road Curve - Top Right.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: a9899bca720d8e345a77e784656807db
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -47,8 +47,8 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spritePixelsToUnits: 256
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Air - Base.png
+++ b/Assets/Sprites/Tower/Tower - Air - Base.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e8b72616f6d2d609a05cf31d18907536487d95b3315afc0573357607bb4861c
+size 4800

--- a/Assets/Sprites/Tower/Tower - Air - Base.png.meta
+++ b/Assets/Sprites/Tower/Tower - Air - Base.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 0978bd3f5eb6bbe4d85c76194c298211
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Air - Turret.png
+++ b/Assets/Sprites/Tower/Tower - Air - Turret.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bb09e29a838534ab76a11dd314b2ce7465c6ba0df5390e94e46b4599a7f60b7
+size 859

--- a/Assets/Sprites/Tower/Tower - Air - Turret.png.meta
+++ b/Assets/Sprites/Tower/Tower - Air - Turret.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: c4c9ca560e552c74e9058aec7c4892fb
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Air.png.meta
+++ b/Assets/Sprites/Tower/Tower - Air.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 256
+  spritePixelsToUnits: 150
   spriteBorder: {x: 53, y: 53, z: 53, w: 7}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/Assets/Sprites/Tower/Tower - Missile - Base.png
+++ b/Assets/Sprites/Tower/Tower - Missile - Base.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe469c8126b0be1815d5a1d51a4258917c5104946a1d1f80dd1fdb67cec04d5d
+size 2130

--- a/Assets/Sprites/Tower/Tower - Missile - Base.png.meta
+++ b/Assets/Sprites/Tower/Tower - Missile - Base.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: e85bd32851835484aae8eb23b5a00edc
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Missile - Turret.png
+++ b/Assets/Sprites/Tower/Tower - Missile - Turret.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d295d29cc1aa917b53a9baf4a37d2761988fcf16bf84e7fd109a198469dcb737
+size 3531

--- a/Assets/Sprites/Tower/Tower - Missile - Turret.png.meta
+++ b/Assets/Sprites/Tower/Tower - Missile - Turret.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: a8a4c8e493bf2184c96f4be1af515de1
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Missile.png.meta
+++ b/Assets/Sprites/Tower/Tower - Missile.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 256
+  spritePixelsToUnits: 150
   spriteBorder: {x: 53, y: 53, z: 53, w: 53}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/Assets/Sprites/Tower/Tower - Normal - Base - Turret.png
+++ b/Assets/Sprites/Tower/Tower - Normal - Base - Turret.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e24fd95f5daf7d912db688d954b00d6a2c79dd07936dbca881a390911caa2bbb
+size 3557

--- a/Assets/Sprites/Tower/Tower - Normal - Base - Turret.png.meta
+++ b/Assets/Sprites/Tower/Tower - Normal - Base - Turret.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 4f7a1299c3a529b429dd9d844036d93e
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Normal - Base.png
+++ b/Assets/Sprites/Tower/Tower - Normal - Base.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9fb2e4b248f38f52e10505a842b84c192c0bb043b6e0be355bae6c492900c17
+size 1179

--- a/Assets/Sprites/Tower/Tower - Normal - Base.png.meta
+++ b/Assets/Sprites/Tower/Tower - Normal - Base.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 041520718a4d0d347ab3184da15b077f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Normal.png.meta
+++ b/Assets/Sprites/Tower/Tower - Normal.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 256
+  spritePixelsToUnits: 150
   spriteBorder: {x: 53, y: 53, z: 53, w: 25}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/Assets/Sprites/Tower/Tower - Slow - Base.png
+++ b/Assets/Sprites/Tower/Tower - Slow - Base.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86ba5e1da9adb531ae5bfe44621f35bcc529f0659f9ddf66b37b668c8e0ccf2e
+size 2830

--- a/Assets/Sprites/Tower/Tower - Slow - Base.png.meta
+++ b/Assets/Sprites/Tower/Tower - Slow - Base.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 06e3ea7dd39a1d64aa5a9a6a97a9c26b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Slow - Turret.png
+++ b/Assets/Sprites/Tower/Tower - Slow - Turret.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bbffb736f2ccbab097ce06cff8af4eaf3694e7985a21a0e7482f256db61ba56
+size 6964

--- a/Assets/Sprites/Tower/Tower - Slow - Turret.png.meta
+++ b/Assets/Sprites/Tower/Tower - Slow - Turret.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: ad2eb2b859344904bb70848d3d108ecd
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Slow.png.meta
+++ b/Assets/Sprites/Tower/Tower - Slow.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 256
+  spritePixelsToUnits: 150
   spriteBorder: {x: 53, y: 53, z: 53, w: 53}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/Assets/Sprites/Tower/Tower - Sniper - Base.png
+++ b/Assets/Sprites/Tower/Tower - Sniper - Base.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57d5d6f2584ba9d07a47685ec633205317d4709a1e092408e798be2bbb2ca18a
+size 5661

--- a/Assets/Sprites/Tower/Tower - Sniper - Base.png.meta
+++ b/Assets/Sprites/Tower/Tower - Sniper - Base.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: ebc7d4d7927eeb54390b1273f1cab284
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Sniper - Turret.png
+++ b/Assets/Sprites/Tower/Tower - Sniper - Turret.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cf7cff9fb5148693a449c404ba8963cfa3e91e4b9d9d443117b215e3950dfd2
+size 993

--- a/Assets/Sprites/Tower/Tower - Sniper - Turret.png.meta
+++ b/Assets/Sprites/Tower/Tower - Sniper - Turret.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: dc824b22baaa61344b577c0d23b217fb
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Sniper.png.meta
+++ b/Assets/Sprites/Tower/Tower - Sniper.png.meta
@@ -47,7 +47,7 @@ TextureImporter:
   spriteMeshType: 0
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 256
+  spritePixelsToUnits: 150
   spriteBorder: {x: 53, y: 53, z: 53, w: 3}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/Assets/Sprites/Tower/Tower - Splash - Base.png
+++ b/Assets/Sprites/Tower/Tower - Splash - Base.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aaf0f025ec7903d9693b530ae4117877a9758d61477bb00e50e9cccacbdd3b9
+size 4885

--- a/Assets/Sprites/Tower/Tower - Splash - Base.png.meta
+++ b/Assets/Sprites/Tower/Tower - Splash - Base.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 0c3ab0ff49565b543a69ffbcc44566dd
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []

--- a/Assets/Sprites/Tower/Tower - Splash - Turret.png
+++ b/Assets/Sprites/Tower/Tower - Splash - Turret.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d89063b9b21415f15c8a366bdb5aaf9ad1568b23a7ecf9f04e9e3a1ad5c46c2
+size 2748

--- a/Assets/Sprites/Tower/Tower - Splash - Turret.png.meta
+++ b/Assets/Sprites/Tower/Tower - Splash - Turret.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68f9b2f3b60b0a74f8d766a478001856
+guid: 6a4b66afd4ae85f4183cc5190920ce36
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -48,7 +48,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 150
-  spriteBorder: {x: 53, y: 53, z: 53, w: 14}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -132,7 +132,7 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
-    internalID: 1537655665
+    internalID: 0
     vertices: []
     indices: 
     edges: []


### PR DESCRIPTION
Commit changes to Tower and new tiles for Road, as requested by Virya and William respectively

Tower is split into base and turret and each had its PPU value set to 150, with Full Rect also enabled just in case

Road tile are made into 4 types: Road, Road Curve, Portal and Home Base. Because TileMap doesn't allow flipping, so each type is made into the following: Horizontal & Vertical for Road and Home Base and 4 corners for Road Curve and Portal. Each had its PPU value set to 256 with Full Rect enabled.